### PR TITLE
feat: add support for Codeberg repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 📦 `Zero dependencies` / `Un/packed (~67/25kb)` / `Faster and more features` yet drop-in replacement for `degit`
 
-> #### Just `copy-and-paste` any GitHub, GitLab or Bitbucket URL - no editing required (shorthands work too) - to clone individual files, folders, branches, commits, raw content or even entire repositories without the `.git` directory.
+> #### Just `copy-and-paste` any GitHub, GitLab, Bitbucket or Codeberg URL - no editing required (shorthands work too) - to clone individual files, folders, branches, commits, raw content or even entire repositories without the `.git` directory.
 
 Unlike other tools that force you to tweak URLs or follow strict formats to clone files, folders, branches or commits GitPick works seamlessly with any URL.
 
@@ -73,6 +73,9 @@ npx gitpick https://gitlab.com/owner/repo/-/tree/main/path/to/folder
 # clone from Bitbucket
 npx gitpick https://bitbucket.org/owner/repo
 npx gitpick https://bitbucket.org/owner/repo/src/main/path/to/folder
+# clone from Codeberg
+npx gitpick https://codeberg.org/owner/repo
+npx gitpick https://codeberg.org/owner/repo/src/branch/main/path/to/folder
 # dry run (preview without cloning)
 npx gitpick owner/repo --dry-run
 npx gitpick owner/repo -i --dry-run
@@ -82,7 +85,7 @@ npx gitpick owner/repo -i --dry-run
 
 ## ✨ Features
 
-- 🔍 Clone individual files or folders from GitHub, GitLab and Bitbucket
+- 🔍 Clone individual files or folders from GitHub, GitLab, Bitbucket and Codeberg
 - 🧠 Use shorthands `TanStack/router` or full URL's `https://github.com/TanStack/router`
 - ⚙️ Auto-detects branches and target directory (if not specified) like `git clone`
 - **🔥 Interactive mode** - browse and cherry-pick files/folders with `-i` | `--interactive`
@@ -122,6 +125,7 @@ npx gitpick <url/shorthand> --dry-run               # preview without cloning
 npx gitpick https://<token>@github.com/owner/repo   # private repository
 npx gitpick https://gitlab.com/owner/repo           # GitLab
 npx gitpick https://bitbucket.org/owner/repo        # Bitbucket
+npx gitpick https://codeberg.org/owner/repo         # Codeberg
 ```
 
 <img width="720" alt="Image" src="https://github.com/user-attachments/assets/ddbc41b4-bfc6-4287-bb85-eb949d723591" />
@@ -156,22 +160,24 @@ npx gitpick owner/repo -i
 npx gitpick owner/repo -i -b canary
 npx gitpick https://github.com/owner/repo -i
 npx gitpick https://gitlab.com/owner/repo -i
+npx gitpick https://codeberg.org/owner/repo -i
 ```
 
 <img width="720" alt="Interactive Mode" src="https://github.com/user-attachments/assets/9d6f4db7-ed84-4783-b815-0267719b3a52" />
 
-Navigate with arrow keys, select with space, expand/collapse with enter, `.` to select all, `c` to confirm. Works with GitHub, GitLab, Bitbucket, public and private repos.
+Navigate with arrow keys, select with space, expand/collapse with enter, `.` to select all, `c` to confirm. Works with GitHub, GitLab, Bitbucket, Codeberg, public and private repos.
 
 ---
 
 ## 🔐 Private Repos
 
-Use a personal access token with read-only contents permission. Works with GitHub, GitLab and Bitbucket:
+Use a personal access token with read-only contents permission. Works with GitHub, GitLab, Bitbucket and Codeberg:
 
 ```sh
 npx gitpick https://<token>@github.com/owner/repo
 npx gitpick https://<token>@gitlab.com/owner/repo
 npx gitpick https://<token>@bitbucket.org/owner/repo
+npx gitpick https://<token>@codeberg.org/owner/repo
 ```
 
 Or use environment variables (recommended for CI):
@@ -180,6 +186,7 @@ Or use environment variables (recommended for CI):
 export GITHUB_TOKEN=ghp_xxxx    # or GH_TOKEN
 export GITLAB_TOKEN=glpat-xxxx
 export BITBUCKET_TOKEN=xxxx
+export CODEBERG_TOKEN=xxxx
 
 npx gitpick owner/private-repo  # token is picked up automatically
 ```
@@ -223,6 +230,9 @@ Create a `.gitpick.json` or `.gitpick.jsonc` in your project to pick multiple fi
   // Bitbucket
   "https://bitbucket.org/owner/repo",
   "https://bitbucket.org/owner/repo/src/main/path/to/folder",
+  // Codeberg
+  "https://codeberg.org/owner/repo",
+  "https://codeberg.org/owner/repo/src/branch/main/path/to/folder",
 ]
 ```
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -19,7 +19,7 @@ import { name, version } from "~/package.json"
 const terminalLink = (text: string, url: string) => `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`
 
 const helpMessage = `
-With ${bold(`${terminalLink("GitPick", "https://github.com/nrjdalal/gitpick")}`)} clone specific directories or files from GitHub, GitLab and Bitbucket!
+With ${bold(`${terminalLink("GitPick", "https://github.com/nrjdalal/gitpick")}`)} clone specific directories or files from GitHub, GitLab, Bitbucket and Codeberg!
 
   $ gitpick ${yellow("<url>")} ${green("[target]")} ${cyan("[options]")}
 
@@ -28,7 +28,7 @@ ${bold("Hint:")}
   GitPick fallbacks to the default behavior of \`git clone\`
 
 ${bold("Arguments:")}
-  ${yellow("url")}                GitHub/GitLab/Bitbucket URL with path to file/folder/repository
+  ${yellow("url")}                GitHub/GitLab/Bitbucket/Codeberg URL with path to file/folder/repository
   ${green("target")}             Directory to clone into (optional)
 
 ${bold("Options:")}
@@ -54,7 +54,8 @@ ${bold("Examples:")}
   $ gitpick <url> --dry-run
   $ gitpick https://gitlab.com/owner/repo
   $ gitpick https://bitbucket.org/owner/repo
-  
+  $ gitpick https://codeberg.org/owner/repo
+
 🚀 More awesome tools at ${cyan("https://github.com/nrjdalal")}`
 
 const displayPath = (targetPath: string) => {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -392,7 +392,7 @@ const main = async () => {
 
     if (!silent) {
       console.log(
-        `\nWith ${bold(`${terminalLink("GitPick", "https://github.com/nrjdalal/gitpick")}`)} clone specific files, folders, branches,\ncommits and much more from GitHub, GitLab and Bitbucket!`,
+        `\nWith ${bold(`${terminalLink("GitPick", "https://github.com/nrjdalal/gitpick")}`)} clone specific files, folders, branches,\ncommits and much more from GitHub, GitLab, Bitbucket and Codeberg!`,
       )
     }
 

--- a/bin/utils/transform-url.ts
+++ b/bin/utils/transform-url.ts
@@ -1,6 +1,6 @@
 import { getDefaultBranch } from "@/utils/get-default-branch"
 
-type Host = "github.com" | "gitlab.com" | "bitbucket.org"
+type Host = "github.com" | "gitlab.com" | "bitbucket.org" | "codeberg.org"
 
 const PREFIXES: { prefix: string; host: Host }[] = [
   { prefix: "git@github.com:", host: "github.com" },
@@ -10,6 +10,8 @@ const PREFIXES: { prefix: string; host: Host }[] = [
   { prefix: "https://gitlab.com/", host: "gitlab.com" },
   { prefix: "git@bitbucket.org:", host: "bitbucket.org" },
   { prefix: "https://bitbucket.org/", host: "bitbucket.org" },
+  { prefix: "git@codeberg.org:", host: "codeberg.org" },
+  { prefix: "https://codeberg.org/", host: "codeberg.org" },
 ]
 
 export async function configFromUrl(
@@ -22,7 +24,7 @@ export async function configFromUrl(
     target?: string | null
   },
 ) {
-  const tokenRegex = /^https:\/\/([^@]+)@(github\.com|gitlab\.com|bitbucket\.org)/
+  const tokenRegex = /^https:\/\/([^@]+)@(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)/
   const tokenMatch = url.match(tokenRegex)
 
   let token = ""
@@ -34,6 +36,7 @@ export async function configFromUrl(
       "github.com": process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "",
       "gitlab.com": process.env.GITLAB_TOKEN || "",
       "bitbucket.org": process.env.BITBUCKET_TOKEN || "",
+      "codeberg.org": process.env.CODEBERG_TOKEN || "",
     }
     // Detect host early to pick the right env var
     for (const { prefix, host: h } of PREFIXES) {
@@ -108,12 +111,23 @@ export async function configFromUrl(
       resolvedBranch = branch || (await getDefaultBranch(repoUrl))
       resolvedPath = ""
     }
-  } else {
+  } else if (host === "bitbucket.org") {
     // bitbucket.org — uses /src/branch/path for both files and dirs
     if (split[2] === "src") {
       type = "tree"
       resolvedBranch = branch || split[3]
       resolvedPath = split.slice(4).join("/")
+    } else {
+      type = "repository"
+      resolvedBranch = branch || (await getDefaultBranch(repoUrl))
+      resolvedPath = ""
+    }
+  } else {
+    // codeberg.org — uses /src/branch|tag|commit/<ref>/path for both files and dirs
+    if (split[2] === "src" && ["branch", "tag", "commit"].includes(split[3])) {
+      type = "tree"
+      resolvedBranch = branch || split[4]
+      resolvedPath = split.slice(5).join("/")
     } else {
       type = "repository"
       resolvedBranch = branch || (await getDefaultBranch(repoUrl))

--- a/bin/utils/transform-url.ts
+++ b/bin/utils/transform-url.ts
@@ -123,9 +123,13 @@ export async function configFromUrl(
       resolvedPath = ""
     }
   } else if (host === "codeberg.org") {
-    // codeberg.org — uses /src/branch|tag|commit/<ref>/path for both files and dirs
-    if (split[2] === "src" && ["branch", "tag", "commit"].includes(split[3])) {
-      type = "tree"
+    // codeberg.org — /src/<branch|tag|commit>/<ref>/path for files+dirs,
+    // /raw/... and /media/... for direct file (blob) links
+    if (
+      ["src", "raw", "media"].includes(split[2]) &&
+      ["branch", "tag", "commit"].includes(split[3])
+    ) {
+      type = split[2] === "src" ? "tree" : "blob"
       resolvedBranch = branch || split[4]
       resolvedPath = split.slice(5).join("/")
     } else {

--- a/bin/utils/transform-url.ts
+++ b/bin/utils/transform-url.ts
@@ -122,7 +122,7 @@ export async function configFromUrl(
       resolvedBranch = branch || (await getDefaultBranch(repoUrl))
       resolvedPath = ""
     }
-  } else {
+  } else if (host === "codeberg.org") {
     // codeberg.org — uses /src/branch|tag|commit/<ref>/path for both files and dirs
     if (split[2] === "src" && ["branch", "tag", "commit"].includes(split[3])) {
       type = "tree"
@@ -133,6 +133,9 @@ export async function configFromUrl(
       resolvedBranch = branch || (await getDefaultBranch(repoUrl))
       resolvedPath = ""
     }
+  } else {
+    const _exhaustive: never = host
+    throw new Error(`Unsupported host: ${_exhaustive}`)
   }
 
   const resolvedTarget = target

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Clone exactly what you need aka straightforward project scaffolding!",
   "keywords": [
     "clone",
+    "codeberg",
     "degit",
     "directory",
     "file",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Clone exactly what you need aka straightforward project scaffolding!",
   "keywords": [
     "clone",
-    "codeberg",
     "degit",
     "directory",
     "file",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -490,6 +490,46 @@ describe("dry-run — URL parsing without cloning", () => {
       ),
     30000,
   )
+
+  // codeberg
+  it(
+    "codeberg repo",
+    () =>
+      dryRun(
+        ["https://codeberg.org/Codeberg/avatars", "-b", "main"],
+        "Codeberg/avatars repository:main > avatars",
+      ),
+    30000,
+  )
+  it(
+    "codeberg src/branch path",
+    () =>
+      dryRun(
+        ["https://codeberg.org/Codeberg/avatars/src/branch/main/example"],
+        "Codeberg/avatars tree:main example > example",
+      ),
+    30000,
+  )
+  it(
+    "codeberg src/tag path",
+    () =>
+      dryRun(
+        ["https://codeberg.org/Codeberg/avatars/src/tag/v1.0.0/example"],
+        "Codeberg/avatars tree:v1.0.0 example > example",
+      ),
+    30000,
+  )
+  it(
+    "codeberg src/commit path",
+    () =>
+      dryRun(
+        [
+          "https://codeberg.org/Codeberg/avatars/src/commit/c86887927797ce57a7e4666494903a4e9b1e901c/example",
+        ],
+        "Codeberg/avatars tree:c86887927797ce57a7e4666494903a4e9b1e901c example > example",
+      ),
+    30000,
+  )
 })
 
 // =====================================================================

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -530,6 +530,42 @@ describe("dry-run — URL parsing without cloning", () => {
       ),
     30000,
   )
+  it(
+    "codeberg raw/branch file",
+    () =>
+      dryRun(
+        ["https://codeberg.org/Codeberg/avatars/raw/branch/main/README.md"],
+        "Codeberg/avatars blob:main README.md > ./README.md",
+      ),
+    30000,
+  )
+  it(
+    "codeberg media/branch file",
+    () =>
+      dryRun(
+        ["https://codeberg.org/Codeberg/avatars/media/branch/main/README.md"],
+        "Codeberg/avatars blob:main README.md > ./README.md",
+      ),
+    30000,
+  )
+  it(
+    "codeberg git@ repo",
+    () =>
+      dryRun(
+        ["git@codeberg.org:Codeberg/avatars", "-b", "main"],
+        "Codeberg/avatars repository:main > avatars",
+      ),
+    30000,
+  )
+  it(
+    "codeberg git@ src path",
+    () =>
+      dryRun(
+        ["git@codeberg.org:Codeberg/avatars/src/branch/main/example"],
+        "Codeberg/avatars tree:main example > example",
+      ),
+    30000,
+  )
 })
 
 // =====================================================================


### PR DESCRIPTION
Hi! 👋 

I maintain two templates on Codeberg (and plan to have more) and I would like to use GitPick as the recommended tool to get a copy of them. Therefore, this PR adds support for Codeberg repos, similar to the other already supported providers.

## Considerations

- Added some tests inspired by the BitBucket ones.
- Used one of the repos from the Codeberg organization for the new tests. Chose a small repo that have Git tags in order to test the three URL combinations.
- Manually tested "cloning" one of my template repos using the commands below. 
- Also tested "cloning" one of my private repos (this feature is not well documented yet, [but it works](https://codeberg.org/Codeberg/Documentation/pulls/459)).
- Used AI (Kiro + Claude Opus 4.6) just to review the code I added.

```bash
bun run build && bun run dist/index.mjs -i https://codeberg.org/joaopalmeiro/template-rust-script
```

```bash
bun run build && bun run dist/index.mjs https://codeberg.org/joaopalmeiro/template-rust-script tmp
```

Any feedback, let me know. Thanks!