### PR TITLE
feat: add --init and --commit flags for git initialization after clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npx gitpick owner/repo -i --dry-run
 - **🔥 Interactive mode** - browse and cherry-pick files/folders with `-i` | `--interactive`
 - 🔐 Seamlessly works with both public and private repositories using a PAT
 - 📦 Can easily clone all submodules with `-r` | `--recursive`
+- 🧱 Initialize cloned output as a new git repo with `--init`
 - 🔎 Preview what would be cloned with `--dry-run` before cloning
 - 🌳 View cloned file structure as a colored tree with `--tree`
 - 🗑️ Overwrite or replace existing files without a prompt using `-o` | `--overwrite`
@@ -115,6 +116,7 @@ npx gitpick owner/repo/blob/main/path/to/file       # a file aka blob
 npx gitpick <url/shorthand>                         # default git behavior
 npx gitpick <url/shorthand> [target]                # with optional target
 npx gitpick <url/shorthand> -b [branch/SHA]         # branch or commit SHA
+npx gitpick <url/shorthand> --init                  # initialize as a new git repository
 npx gitpick <url/shorthand> -o                      # overwrite if exists
 npx gitpick <url/shorthand> -r                      # clone submodules
 npx gitpick <url/shorthand> -w 30s                  # sync every 30 seconds
@@ -132,6 +134,7 @@ npx gitpick https://bitbucket.org/owner/repo        # Bitbucket
 
 ```
 -b, --branch       Branch/SHA to clone
+-    --init        Initialize target as a new git repository
 -i, --interactive  Browse and pick files/folders interactively
 -n, --dry-run      Show what would be cloned without cloning
 -o, --overwrite    Skip overwrite prompt

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ npx gitpick https://bitbucket.org/owner/repo        # Bitbucket
 
 ```
 -b, --branch       Branch/SHA to clone
--    --init        Initialize target as a new git repository
+    --init         Initialize target as a new git repository
 -m, --commit <msg> Stage all files and create initial git commit
 -i, --interactive  Browse and pick files/folders interactively
 -n, --dry-run      Show what would be cloned without cloning

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ npx gitpick owner/repo -i --dry-run
 - 🔐 Seamlessly works with both public and private repositories using a PAT
 - 📦 Can easily clone all submodules with `-r` | `--recursive`
 - 🧱 Initialize cloned output as a new git repo with `--init`
+- 💾 Stage and create an initial git commit with `-m`/`--commit <msg>` (implies `--init`)
 - 🔎 Preview what would be cloned with `--dry-run` before cloning
 - 🌳 View cloned file structure as a colored tree with `--tree`
 - 🗑️ Overwrite or replace existing files without a prompt using `-o` | `--overwrite`
@@ -117,6 +118,7 @@ npx gitpick <url/shorthand>                         # default git behavior
 npx gitpick <url/shorthand> [target]                # with optional target
 npx gitpick <url/shorthand> -b [branch/SHA]         # branch or commit SHA
 npx gitpick <url/shorthand> --init                  # initialize as a new git repository
+npx gitpick <url/shorthand> --commit "Initial commit"  # init + stage + initial commit
 npx gitpick <url/shorthand> -o                      # overwrite if exists
 npx gitpick <url/shorthand> -r                      # clone submodules
 npx gitpick <url/shorthand> -w 30s                  # sync every 30 seconds
@@ -135,6 +137,7 @@ npx gitpick https://bitbucket.org/owner/repo        # Bitbucket
 ```
 -b, --branch       Branch/SHA to clone
 -    --init        Initialize target as a new git repository
+-m, --commit <msg> Stage all files and create initial git commit
 -i, --interactive  Browse and pick files/folders interactively
 -n, --dry-run      Show what would be cloned without cloning
 -o, --overwrite    Skip overwrite prompt

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ npx gitpick https://bitbucket.org/owner/repo        # Bitbucket
 -v, --version      display the version number
 ```
 
+> **Note on `--commit`:** When cloning a single file (`blob`) into an existing non-empty directory, the automated `git add .` command will stage and commit all unrelated files currently present in that directory alongside the cloned file.
+
 ---
 
 ## 🔥 Interactive Mode

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npx gitpick <url/shorthand>                         # default git behavior
 npx gitpick <url/shorthand> [target]                # with optional target
 npx gitpick <url/shorthand> -b [branch/SHA]         # branch or commit SHA
 npx gitpick <url/shorthand> --init                  # initialize as a new git repository
-npx gitpick <url/shorthand> --commit "Initial commit"  # init + stage + initial commit
+npx gitpick <url/shorthand> --commit "init commit"  # init + stage + initial commit
 npx gitpick <url/shorthand> -o                      # overwrite if exists
 npx gitpick <url/shorthand> -r                      # clone submodules
 npx gitpick <url/shorthand> -w 30s                  # sync every 30 seconds

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -34,7 +34,7 @@ ${bold("Arguments:")}
 ${bold("Options:")}
   ${cyan("-b, --branch ")}      Branch/SHA to clone
   ${cyan("    --init")}         Initialize target as a new git repository
-  ${cyan("-m, --commit <msg>")}  Stage all files and create initial git commit
+  ${cyan("-m, --commit <msg>")} Stage all files and create initial git commit
   ${cyan("-i, --interactive")}  Browse and pick files/folders interactively
   ${cyan("-n, --dry-run")}      Show what would be cloned without cloning
   ${cyan("-o, --overwrite")}    Skip overwrite prompt

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -139,7 +139,18 @@ const main = async () => {
   scheduleUpdateCheck()
 
   try {
+    // parseArgs lacks optional strings. To stay zero-dependency, we inject
+    // a default "init awesomeness" when --commit is passed without a value.
+    const args = process.argv.slice(2).reduce((acc, arg, i, arr) => {
+      acc.push(arg)
+      if ((arg === "-m" || arg === "--commit") && (!arr[i + 1] || arr[i + 1].startsWith("-"))) {
+        acc.push("init awesomeness")
+      }
+      return acc
+    }, [] as string[])
+
     const { positionals, values } = parse({
+      args,
       allowPositionals: true,
       options: {
         branch: { type: "string", short: "b" },

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -655,7 +655,6 @@ const main = async () => {
       const watchInterval = parseTimeString(options.watch)
       setInterval(async () => {
         await cloneAction(config, options, targetPath)
-        await initGitRepo(targetPath, config.type, options)
         if (options.tree) await renderTree(targetPath)
       }, watchInterval)
     } else {

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -116,6 +116,14 @@ const initGitRepo = async (
   if (!options.init && !options.commit) return
 
   const repoPath = type === "blob" ? path.dirname(targetPath) : targetPath
+
+  if (type === "blob" && repoPath === process.cwd()) {
+    console.log(
+      `\n✖ Skipping git init: Cannot initialize a git repository for a single file in the current working directory.`,
+    )
+    return
+  }
+
   if (!fs.existsSync(path.join(repoPath, ".git"))) {
     await spawn("git", ["init"], { cwd: repoPath })
   }

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -34,6 +34,7 @@ ${bold("Arguments:")}
 ${bold("Options:")}
   ${cyan("-b, --branch ")}      Branch/SHA to clone
   ${cyan("    --init")}         Initialize target as a new git repository
+  ${cyan("-m, --commit <msg>")}  Stage all files and create initial git commit
   ${cyan("-i, --interactive")}  Browse and pick files/folders interactively
   ${cyan("-n, --dry-run")}      Show what would be cloned without cloning
   ${cyan("-o, --overwrite")}    Skip overwrite prompt
@@ -107,13 +108,22 @@ const parse: typeof parseArgs = (config) => {
   }
 }
 
-const initGitRepo = async (targetPath: string, type: string, options: { init?: boolean }) => {
-  if (!options.init) return
+const initGitRepo = async (
+  targetPath: string,
+  type: string,
+  options: { init?: boolean; commit?: string },
+) => {
+  if (!options.init && !options.commit) return
 
   const repoPath = type === "blob" ? path.dirname(targetPath) : targetPath
-  if (fs.existsSync(path.join(repoPath, ".git"))) return
+  if (!fs.existsSync(path.join(repoPath, ".git"))) {
+    await spawn("git", ["init"], { cwd: repoPath })
+  }
 
-  await spawn("git", ["init"], { cwd: repoPath })
+  if (options.commit) {
+    await spawn("git", ["add", "."], { cwd: repoPath })
+    await spawn("git", ["commit", "-m", options.commit], { cwd: repoPath })
+  }
 }
 
 const main = async () => {
@@ -128,6 +138,7 @@ const main = async () => {
         force: { type: "boolean", short: "f" },
         help: { type: "boolean", short: "h" },
         init: { type: "boolean" },
+        commit: { type: "string", short: "m" },
         interactive: { type: "boolean", short: "i" },
         quiet: { type: "boolean", short: "q" },
         tree: { type: "boolean" },
@@ -167,6 +178,7 @@ const main = async () => {
       dryRun: values["dry-run"],
       force: values.force,
       init: values.init,
+      commit: values.commit,
       interactive: values.interactive,
       quiet: values.quiet,
       tree: values.tree,

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -33,6 +33,7 @@ ${bold("Arguments:")}
 
 ${bold("Options:")}
   ${cyan("-b, --branch ")}      Branch/SHA to clone
+  ${cyan("    --init")}         Initialize target as a new git repository
   ${cyan("-i, --interactive")}  Browse and pick files/folders interactively
   ${cyan("-n, --dry-run")}      Show what would be cloned without cloning
   ${cyan("-o, --overwrite")}    Skip overwrite prompt
@@ -106,6 +107,15 @@ const parse: typeof parseArgs = (config) => {
   }
 }
 
+const initGitRepo = async (targetPath: string, type: string, options: { init?: boolean }) => {
+  if (!options.init) return
+
+  const repoPath = type === "blob" ? path.dirname(targetPath) : targetPath
+  if (fs.existsSync(path.join(repoPath, ".git"))) return
+
+  await spawn("git", ["init"], { cwd: repoPath })
+}
+
 const main = async () => {
   scheduleUpdateCheck()
 
@@ -117,6 +127,7 @@ const main = async () => {
         "dry-run": { type: "boolean", short: "n" },
         force: { type: "boolean", short: "f" },
         help: { type: "boolean", short: "h" },
+        init: { type: "boolean" },
         interactive: { type: "boolean", short: "i" },
         quiet: { type: "boolean", short: "q" },
         tree: { type: "boolean" },
@@ -155,6 +166,7 @@ const main = async () => {
       branch: values.branch,
       dryRun: values["dry-run"],
       force: values.force,
+      init: values.init,
       interactive: values.interactive,
       quiet: values.quiet,
       tree: values.tree,
@@ -384,6 +396,7 @@ const main = async () => {
         await printTree(targetDir)
         process.stdout.write("\n")
       }
+      await initGitRepo(targetDir, "repository", options)
       process.exit(0)
     }
 
@@ -565,6 +578,7 @@ const main = async () => {
           `✔ Copied ${copiedFiles} file${copiedFiles !== 1 ? "s" : ""} to ${displayPath(targetPath)}`,
         ),
       )
+      await initGitRepo(targetPath, "repository", options)
       if (options.tree) {
         process.stdout.write(`\n${bold(cyan(displayPath(targetPath)))}\n`)
         await printTree(targetPath)
@@ -624,14 +638,17 @@ const main = async () => {
       if (!silent)
         console.log(`\n👀 Watching every ${parseTimeString(options.watch) / 1000 + "s"}\n`)
       await cloneAction(config, options, targetPath)
+      await initGitRepo(targetPath, config.type, options)
       if (options.tree) await renderTree(targetPath)
       const watchInterval = parseTimeString(options.watch)
       setInterval(async () => {
         await cloneAction(config, options, targetPath)
+        await initGitRepo(targetPath, config.type, options)
         if (options.tree) await renderTree(targetPath)
       }, watchInterval)
     } else {
       await cloneAction(config, options, targetPath)
+      await initGitRepo(targetPath, config.type, options)
       if (options.tree) await renderTree(targetPath)
       notifyUpdate(version, silent)
       process.exit(0)

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -108,16 +108,13 @@ const parse: typeof parseArgs = (config) => {
   }
 }
 
-const initGitRepo = async (
-  targetPath: string,
-  type: string,
-  options: { init?: boolean; commit?: string },
-) => {
+const initGitRepo = async (targetPath: string, options: { init?: boolean; commit?: string }) => {
   if (!options.init && !options.commit) return
 
-  const repoPath = type === "blob" ? path.dirname(targetPath) : targetPath
+  const isFile = fs.existsSync(targetPath) && fs.statSync(targetPath).isFile()
+  const repoPath = isFile ? path.dirname(targetPath) : targetPath
 
-  if (type === "blob" && repoPath === process.cwd()) {
+  if (isFile && repoPath === process.cwd()) {
     console.log(
       `\n✖ Skipping git init: Cannot initialize a git repository for a single file in the current working directory.`,
     )
@@ -420,7 +417,7 @@ const main = async () => {
         await printTree(targetDir)
         process.stdout.write("\n")
       }
-      await initGitRepo(targetDir, "repository", options)
+      await initGitRepo(targetDir, options)
       process.exit(0)
     }
 
@@ -602,7 +599,7 @@ const main = async () => {
           `✔ Copied ${copiedFiles} file${copiedFiles !== 1 ? "s" : ""} to ${displayPath(targetPath)}`,
         ),
       )
-      await initGitRepo(targetPath, "repository", options)
+      await initGitRepo(targetPath, options)
       if (options.tree) {
         process.stdout.write(`\n${bold(cyan(displayPath(targetPath)))}\n`)
         await printTree(targetPath)
@@ -662,7 +659,7 @@ const main = async () => {
       if (!silent)
         console.log(`\n👀 Watching every ${parseTimeString(options.watch) / 1000 + "s"}\n`)
       await cloneAction(config, options, targetPath)
-      await initGitRepo(targetPath, config.type, options)
+      await initGitRepo(targetPath, options)
       if (options.tree) await renderTree(targetPath)
       const watchInterval = parseTimeString(options.watch)
       setInterval(async () => {
@@ -671,7 +668,7 @@ const main = async () => {
       }, watchInterval)
     } else {
       await cloneAction(config, options, targetPath)
-      await initGitRepo(targetPath, config.type, options)
+      await initGitRepo(targetPath, options)
       if (options.tree) await renderTree(targetPath)
       notifyUpdate(version, silent)
       process.exit(0)

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -56,7 +56,7 @@ ${bold("Examples:")}
   $ gitpick <url> --dry-run
   $ gitpick https://gitlab.com/owner/repo
   $ gitpick https://bitbucket.org/owner/repo
-  
+
 🚀 More awesome tools at ${cyan("https://github.com/nrjdalal")}`
 
 const displayPath = (targetPath: string) => {
@@ -122,7 +122,11 @@ const initGitRepo = async (
 
   if (options.commit) {
     await spawn("git", ["add", "."], { cwd: repoPath })
-    await spawn("git", ["commit", "-m", options.commit], { cwd: repoPath })
+    try {
+      await spawn("git", ["commit", "-m", options.commit], { cwd: repoPath })
+    } catch {
+      console.log(`\n✖ git commit failed — configure user.name / user.email`)
+    }
   }
 }
 

--- a/bin/utils/transform-url.ts
+++ b/bin/utils/transform-url.ts
@@ -12,6 +12,8 @@ const PREFIXES: { prefix: string; host: Host }[] = [
   { prefix: "https://bitbucket.org/", host: "bitbucket.org" },
 ]
 
+export type CloneType = "raw" | "blob" | "tree" | "repository"
+
 export async function configFromUrl(
   url: string,
   {
@@ -64,7 +66,7 @@ export async function configFromUrl(
 
   const repoUrl = `https://${token ? token + "@" : token}${host}/${owner}/${repository}`
 
-  let type: string
+  let type: CloneType
   let resolvedBranch: string
   let resolvedPath: string
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1061,6 +1061,40 @@ describe("--init", () => {
     expect(exitCode).toBe(0)
     expect(existsSync(join(t, ".git"))).toBe(true)
   }, 30000)
+
+  it("creates initial commit for directory clone", async () => {
+    const t = target()
+    const { exitCode } = await run([
+      "clone",
+      "nrjdalal/picksuite/tree/main/folder",
+      t,
+      "--init",
+      "--commit",
+      "Initial commit",
+    ])
+    expect(exitCode).toBe(0)
+    expect(existsSync(join(t, ".git"))).toBe(true)
+    const proc = Bun.spawn(["git", "log", "--oneline"], { stdout: "pipe", cwd: t })
+    const log = await new Response(proc.stdout).text()
+    expect(log).toContain("Initial commit")
+  }, 30000)
+
+  it("creates initial commit in parent dir for blob clone (--commit implies --init)", async () => {
+    const t = target()
+    const blobTarget = join(t, "renamed.txt")
+    const { exitCode } = await run([
+      "clone",
+      "nrjdalal/picksuite/blob/main/file.txt",
+      blobTarget,
+      "--commit",
+      "feat: initial scaffold",
+    ])
+    expect(exitCode).toBe(0)
+    expect(existsSync(join(t, ".git"))).toBe(true)
+    const proc = Bun.spawn(["git", "log", "--oneline"], { stdout: "pipe", cwd: t })
+    const log = await new Response(proc.stdout).text()
+    expect(log).toContain("feat: initial scaffold")
+  }, 30000)
 })
 
 // =====================================================================

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1095,6 +1095,64 @@ describe("--init", () => {
     const log = await new Response(proc.stdout).text()
     expect(log).toContain("feat: initial scaffold")
   }, 30000)
+
+  it("idempotency: calling --init when .git already exists should not error", async () => {
+    const t = target()
+    mkdirSync(join(t, ".git"), { recursive: true })
+    const { exitCode } = await run([
+      "clone",
+      "nrjdalal/picksuite/tree/main/folder",
+      t,
+      "--init",
+      "-o",
+    ])
+    expect(exitCode).toBe(0)
+  }, 30000)
+
+  it("--commit without git user config — confirms the error surface", async () => {
+    const t = target()
+    const proc = Bun.spawn(
+      [...CLI, "clone", "nrjdalal/picksuite/tree/main/folder", t, "--commit", "Init"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "",
+          GIT_COMMITTER_NAME: "",
+          GIT_AUTHOR_EMAIL: "",
+          GIT_COMMITTER_EMAIL: "",
+        },
+      },
+    )
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    await proc.exited
+    expect(stdout + stderr).toMatch(/user\.(name|email)/i)
+  }, 30000)
+})
+
+describe("watch mode", () => {
+  it("assert no crash on the second tick", async () => {
+    const t = target()
+    const proc = Bun.spawn(
+      [...CLI, "clone", "nrjdalal/picksuite/tree/main/folder", t, "-w", "1s"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    )
+
+    // Wait long enough for a second tick
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+    proc.kill()
+    const stdout = await new Response(proc.stdout).text()
+
+    // Assert that it didn't crash before being killed
+    expect(stdout).not.toMatch(/error:/i)
+  }, 30000)
 })
 
 // =====================================================================

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1033,6 +1033,34 @@ describe("CLI flags", () => {
     expect(exitCode).toBe(0)
     expect(parseLine(output)).toContain("nrjdalal/picksuite repository:main")
   }, 30000)
+
+  it("--help includes --init", async () => {
+    const { output, exitCode } = await run(["--help"])
+    expect(exitCode).toBe(0)
+    expect(stripAnsi(output)).toContain("--init")
+  })
+})
+
+describe("--init", () => {
+  it("initializes git repository for directory clone", async () => {
+    const t = target()
+    const { exitCode } = await run(["clone", "nrjdalal/picksuite/tree/main/folder", t, "--init"])
+    expect(exitCode).toBe(0)
+    expect(existsSync(join(t, ".git"))).toBe(true)
+  }, 30000)
+
+  it("initializes git repository in parent dir for blob clone", async () => {
+    const t = target()
+    const blobTarget = join(t, "renamed.txt")
+    const { exitCode } = await run([
+      "clone",
+      "nrjdalal/picksuite/blob/main/file.txt",
+      blobTarget,
+      "--init",
+    ])
+    expect(exitCode).toBe(0)
+    expect(existsSync(join(t, ".git"))).toBe(true)
+  }, 30000)
 })
 
 // =====================================================================


### PR DESCRIPTION
adds two new CLI flags that let users initialize a git repository and optionally
create an initial commit immediately after cloning with no extra manual steps needed.

closes #61 

## Motivation

`gitpick` intentionally strips the `.git` directory when cloning, which is great
for scaffolding. But users who want to immediately start tracking their own changes
had to manually run `git init` (and optionally `git add . && git commit`) after
every clone. This PR adds support to automate that workflow.

## Changes

### `--init` (boolean)
Initializes the target directory as a new git repository after cloning.
- For **tree/repo** clones: runs `git init` inside the target directory.
- For **blob** clones: runs `git init` in the parent directory (the natural repo root).
- Skips silently if a `.git` directory already exists (idempotent).

### `--commit <msg>` / `-m <msg>` (string)
Stages all cloned files and creates an initial git commit with the provided message.
- Implies `--init` -> no need to pass both flags.
- Runs `git add .` then `git commit -m <msg>` after initialization.

---

## Usage

```sh
# Initialize as a git repo, commit later yourself
gitpick owner/repo --init

# Initialize and immediately create an initial commit
gitpick owner/repo --init --commit "Initial commit"

# --commit alone implies --init
gitpick owner/repo --commit "feat: scaffold from template"
gitpick owner/repo/tree/main/src -m "chore: add base source"

# Works with blob clones too (commits from parent dir)
gitpick owner/repo/blob/main/file.txt ./dest/file.txt --commit "feat: add config"
